### PR TITLE
Added Roslyn-based migrator to be used in VisualStudio

### DIFF
--- a/source/VisualStudio.AndroidX.Migration/Console/App.config
+++ b/source/VisualStudio.AndroidX.Migration/Console/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/source/VisualStudio.AndroidX.Migration/Console/Console.csproj
+++ b/source/VisualStudio.AndroidX.Migration/Console/Console.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Console</RootNamespace>
+    <AssemblyName>Console</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{297b120f-de08-4460-bce6-5b2a74535c2d}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime">
+      <Version>16.0.461</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime">
+      <Version>16.0.461</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Locator" ExcludeAssets="runtime">
+      <Version>1.2.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime">
+      <Version>16.0.461</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime">
+      <Version>16.0.461</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/source/VisualStudio.AndroidX.Migration/Console/Program.cs
+++ b/source/VisualStudio.AndroidX.Migration/Console/Program.cs
@@ -1,0 +1,18 @@
+﻿using Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Console
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			var runner = new MigrationRunner();
+			runner.MigrateSolution(args[0]);
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Console/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.AndroidX.Migration/Console/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Console")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Console")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("29e0e329-b35e-4a6c-b24d-e4700c6ba58f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/VisualStudio.AndroidX.Migration/Core/Core.csproj
+++ b/source/VisualStudio.AndroidX.Migration/Core/Core.csproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{297B120F-DE08-4460-BCE6-5B2A74535C2D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Core</RootNamespace>
+    <AssemblyName>Core</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <BaseIntermediateOutputPath>obj</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MigrationRunner.cs" />
+    <Compile Include="ProjectRewriter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rewriters\MigrationRewriter.cs" />
+    <Compile Include="Rewriters\NamespaceRewriter.cs" />
+    <Compile Include="Rewriters\SemanticRewriter.cs" />
+    <Compile Include="Rewriters\TypeRewriter.cs" />
+    <Compile Include="TranslationResolver.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime">
+      <Version>16.0.461</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>3.2.0-beta3-final</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <Version>3.2.0-beta3-final</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+      <Version>3.2.0-beta3-final</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild">
+      <Version>3.2.0-beta3-final</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\mappings\androidx-assemblies.csv">
+      <Link>Resources\androidx-assemblies.csv</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\mappings\androidx-mapping.csv">
+      <Link>Resources\androidx-mapping.csv</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/source/VisualStudio.AndroidX.Migration/Core/MigrationRunner.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/MigrationRunner.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using VisualStudio.AndroidX.Migration;
+using System.Reflection;
+
+namespace Core
+{
+	public class MigrationRunner
+	{
+		private TranslationResolver resolver;
+
+		public MigrationRunner()
+		{
+			var androidDirectory = Path.Combine(Path.GetDirectoryName(typeof(MigrationRunner).Assembly.Location), "Assemblies\\Android");
+			var androidXDirectory = Path.Combine(Path.GetDirectoryName(typeof(MigrationRunner).Assembly.Location), "Assemblies\\AndroidX");
+
+			resolver = new TranslationResolver(null, null);
+		}
+
+		public void MigrateSolution(string solutionPath)
+		{
+			var workspace = MSBuildWorkspace.Create();
+			workspace.WorkspaceFailed += (s,e) => { Console.WriteLine(e.Diagnostic.Message); };
+			var solution = workspace.OpenSolutionAsync(solutionPath).Result;
+
+			var newSolution = solution;
+
+			foreach (var project in solution.Projects)
+			{
+				newSolution = MigrateProject(project, newSolution);
+			}
+
+			workspace.TryApplyChanges(newSolution);
+		}
+
+		public Solution MigrateProject(Project project, Solution solution)
+		{
+			foreach (var reference in project.MetadataReferences)
+				if (resolver.Nugets.Keys.Contains(Path.GetFileNameWithoutExtension(reference.Display)) && !resolver.AndroidAssemblies.Any(a => Path.GetFileName(a.CodeBase) == Path.GetFileName(reference.Display)))
+					resolver.AndroidAssemblies.Add(Assembly.ReflectionOnlyLoadFrom(reference.Display));
+			solution = MigrateDocuments(project, solution);
+			MigrateNugets(project);
+			foreach (var reference in project.MetadataReferences)
+				if (resolver.Nugets.Values.Any(v => v.Key == (Path.GetFileNameWithoutExtension(reference.Display))) && !resolver.AndroidXAssemblies.Any(a => Path.GetFileName(a.CodeBase) == Path.GetFileName(reference.Display)))
+					resolver.AndroidXAssemblies.Add(Assembly.ReflectionOnlyLoadFrom(reference.Display));
+			solution = PostProcessProject(project, solution);
+			Jetify(project);
+
+			return solution;
+		}
+
+		private Solution MigrateDocuments(Project project, Solution solution)
+		{
+			var rewriters = new List<IRewriter>
+			{
+				new TypeRewriter(resolver),
+				new SemanticRewriter(resolver)
+			};
+
+			foreach (var document in project.Documents)
+			{
+				solution = MigrateDocument(document, solution, rewriters);
+			}
+
+			return solution;
+		}
+
+		private void MigrateNugets(Project project)
+		{
+			var rewriter = new ProjectRewriter(resolver);
+			rewriter.RewriteProject(project.FilePath);
+		}
+
+		private Solution PostProcessProject(Project project, Solution solution)
+		{
+			var rewriters = new List<IRewriter>
+			{
+				new NamespaceRewriter(resolver)
+			};
+
+			foreach (var document in project.Documents)
+			{
+				solution = MigrateDocument(document, solution, rewriters);
+			}
+
+			return solution;
+		}
+
+		private Solution MigrateDocument(Document document, Solution solution, List<IRewriter> rewriters)
+		{
+			foreach(var rewriter in rewriters)
+			{
+				solution = rewriter.Visit(solution, document);
+			}
+
+			return solution;
+		}
+
+		private void Jetify(Project project)
+		{
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/ProjectRewriter.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/ProjectRewriter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using System.Xml;
+using System.IO;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class ProjectRewriter
+	{
+		private ITranslationResolver resolver;
+
+		public ProjectRewriter(ITranslationResolver resolver)
+		{
+			this.resolver = resolver;
+		}
+
+		public void RewriteProject(string projectFileName)
+		{ 
+			var xml = RewriteCSProj(File.ReadAllText(projectFileName));
+			File.WriteAllText(projectFileName, xml);
+		}
+
+		public string RewriteCSProj(string csproj)
+		{
+			var doc = new XmlDocument();
+			doc.PreserveWhitespace = true;
+			doc.LoadXml(csproj);
+			var itemGroups = doc.GetElementsByTagName("ItemGroup");
+			foreach (var group in itemGroups.OfType<XmlElement>())
+			{
+				//var replacements = new Dictionary<XmlElement, XmlElement>();
+				var references = group.ChildNodes.OfType<XmlElement>().Where(c => c.Name == "PackageReference");
+				foreach (var reference in references)
+				{
+					var androidNuget = reference.Attributes["Include"].InnerText;
+					if (resolver.Nugets.ContainsKey(androidNuget))
+					{
+						reference.Attributes["Include"].InnerText = resolver.Nugets[reference.Attributes["Include"].InnerText].Key;
+						var androidXVersion = resolver.Nugets[androidNuget].Value;
+						if (reference.HasAttribute("Version"))
+						{
+							reference.Attributes["Version"].InnerText = androidXVersion;
+						} 
+						else 
+						{
+							var version = reference.ChildNodes.OfType<XmlElement>().FirstOrDefault(n => n.Name == "Version");
+							if (version != null)
+							{ 
+								version.InnerText = androidXVersion;
+							}
+							else
+							{
+								var versionAttribute = doc.CreateAttribute("Version");
+								versionAttribute.InnerText = androidXVersion;
+								reference.Attributes.Append(versionAttribute);
+							}
+							//var replacement = doc.CreateElement(reference.Name, reference.NamespaceURI);
+							//foreach (var attribute in reference.Attributes.OfType<XmlAttribute>())
+							//{
+							//	replacement.Attributes.Append(attribute);
+							//}
+							//replacements.Add(reference, replacement);
+							}
+					}
+				}
+				//foreach (var replacement in replacements)
+				//{
+				//	group.ReplaceChild(replacement.Value, replacement.Key);
+				//}
+			}
+			return doc.InnerXml;
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Core")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Core")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("297b120f-de08-4460-bce6-5b2a74535c2d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/VisualStudio.AndroidX.Migration/Core/Rewriters/MigrationRewriter.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/Rewriters/MigrationRewriter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public abstract class MigrationRewriter : CSharpSyntaxRewriter, IRewriter
+	{
+		public SemanticModel Semantic { get; set; }
+		protected ITranslationResolver resolver;
+
+		internal abstract bool UsesSemantic { get; }
+
+		public MigrationRewriter(ITranslationResolver resolver)
+		{
+			this.resolver = resolver;
+		}
+
+		public Solution Visit(Solution solution, Document document)
+		{
+			if (UsesSemantic)
+				this.Semantic = document.Project.GetCompilationAsync().Result.GetSemanticModel(document.GetSyntaxRootAsync().Result.SyntaxTree);
+			var root = this.Visit(document.GetSyntaxRootAsync().Result);
+			return solution.WithDocumentSyntaxRoot(document.Id, root);
+		}
+
+		internal bool TryGetValue(string name, out string typeName)
+		{
+			typeName = string.Empty;
+			if (resolver.FullTypeNames.ContainsKey(name))
+			{
+				typeName = resolver.FullTypeNames[name];
+				return true;
+			}
+
+			return false;
+		}
+
+	}
+
+	public interface IRewriter
+	{
+		Solution Visit(Solution solution, Document document);
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/Rewriters/NamespaceRewriter.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/Rewriters/NamespaceRewriter.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class NamespaceRewriter : MigrationRewriter
+	{
+		private ITranslationResolver assemblyResolver;
+
+		internal override bool UsesSemantic => false;
+
+		public NamespaceRewriter(ITranslationResolver assemblyResolver) : base(assemblyResolver)
+		{
+			this.assemblyResolver = assemblyResolver;
+		}
+
+		public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
+		{
+			var name = node.Name.WithoutTrivia().ToFullString();
+			if (assemblyResolver.Namespaces.ContainsKey(name))
+				return base.VisitUsingDirective(node.WithName(SyntaxFactory.ParseName(assemblyResolver.Namespaces[name])
+					.WithLeadingTrivia(node.Name.GetLeadingTrivia())
+					.WithTrailingTrivia(node.Name.GetTrailingTrivia())));
+			else
+				return base.VisitUsingDirective(node);
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/Rewriters/SemanticRewriter.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/Rewriters/SemanticRewriter.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class SemanticRewriter : MigrationRewriter
+	{
+		private ITranslationResolver assemblyResolver;
+
+		internal override bool UsesSemantic => true;
+
+		public SemanticRewriter(ITranslationResolver assemblyResolver) : base(assemblyResolver)
+		{
+			this.assemblyResolver = assemblyResolver;
+		}
+
+		public override SyntaxNode VisitQualifiedName(QualifiedNameSyntax node)
+		{
+			var symbol = Semantic.GetSymbolInfo(node);
+			if (symbol.Symbol != null && node.ToFullString() != symbol.Symbol.ToDisplayString())
+				return SyntaxFactory.ParseName(symbol.Symbol.ToDisplayString())
+					.WithLeadingTrivia(node.GetLeadingTrivia())
+					.WithTrailingTrivia(node.GetTrailingTrivia());
+			else
+				return base.VisitQualifiedName(node);
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/Rewriters/TypeRewriter.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/Rewriters/TypeRewriter.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class TypeRewriter : MigrationRewriter
+	{
+		private ITranslationResolver assemblyResolver;
+
+		internal override bool UsesSemantic => false;
+
+		public TypeRewriter(ITranslationResolver assemblyResolver) : base(assemblyResolver)
+		{
+			this.assemblyResolver = assemblyResolver;
+		}
+
+		public override SyntaxNode VisitQualifiedName(QualifiedNameSyntax node)
+		{
+			var name = node.WithoutTrivia().ToFullString();
+			if (TryGetValue(name, out var typeName))
+				return SyntaxFactory.ParseName(typeName)
+					.WithLeadingTrivia(node.GetLeadingTrivia())
+					.WithTrailingTrivia(node.GetTrailingTrivia());
+			else
+				return base.VisitQualifiedName(node);
+		}
+
+		public override SyntaxNode VisitAttribute(AttributeSyntax node)
+		{
+			var typeName = string.Empty;
+			var identifier = node.Name + "Attribute";
+			if (TryGetValue(identifier, out typeName))
+			{
+				if (typeName.EndsWith("Attribute"))
+				{
+					typeName = typeName.Remove(typeName.Length - 9);
+					return node.WithName(SyntaxFactory.ParseName(typeName)
+						.WithLeadingTrivia(node.GetLeadingTrivia())
+						.WithTrailingTrivia(node.GetTrailingTrivia()));
+				}
+			}
+			return base.VisitAttribute(node);
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Core/TranslationResolver.cs
+++ b/source/VisualStudio.AndroidX.Migration/Core/TranslationResolver.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class TranslationResolver : ITranslationResolver
+	{
+		int SupportNamespace = 0;
+		int SupportTypeName = 1;
+		int AndroidXNamespace = 2;
+		int AndroidXTypeName = 3;
+
+		int SupportNuget = 2;
+		int AndroidXNuget = 3;
+		int AndroidXVersion = 4;
+
+		public TranslationResolver(IList<string> androidAssemblyLocations, IList<string> androidXAssemblyLocations)
+		{
+			Namespaces = new Dictionary<string, string>();
+			FullTypeNames = new Dictionary<string, string>();
+			Nugets = new Dictionary<string, KeyValuePair<string, string>>();
+
+			var conversionFile = Path.Combine(Path.GetDirectoryName(this.GetType().Assembly.Location), "Resources\\androidx-mapping.csv");
+			foreach (var line in File.ReadLines(conversionFile).Skip(1))
+			{
+				var values = line.Split(',');
+				if (values[SupportNamespace] != string.Empty && values[AndroidXNamespace] != string.Empty)
+				{ 
+					if (!Namespaces.Any(n => n.Key == values[SupportNamespace]))
+						Namespaces.Add(values[SupportNamespace], values[AndroidXNamespace]);
+
+					if (!FullTypeNames.Any(t => t.Key == $"{values[SupportNamespace]}.{values[SupportTypeName]}"))
+						FullTypeNames.Add($"{values[SupportNamespace]}.{values[SupportTypeName]}", $"{values[AndroidXNamespace]}.{values[AndroidXTypeName]}");
+				}
+
+			}
+
+			AndroidAssemblies = AddAssemblies(androidAssemblyLocations ?? new List<string>(), AndroidAssemblies);
+			AndroidXAssemblies = AddAssemblies(androidXAssemblyLocations ?? new List<string>(), AndroidXAssemblies);
+
+			var nugetsFile = Path.Combine(Path.GetDirectoryName(this.GetType().Assembly.Location), "Resources\\androidx-assemblies.csv");
+			foreach (var line in File.ReadLines(nugetsFile).Skip(1))
+			{
+				var values = line.Split(',');
+				if (!Nugets.Any(n => n.Key == values[SupportNuget]))
+					Nugets.Add(values[SupportNuget], new KeyValuePair<string, string>(values[AndroidXNuget], values[AndroidXVersion]));
+			}
+		}
+
+		public IList<Assembly> AddAssemblies(IList<string> assemblyLocations, IList<Assembly> assemblies)
+		{
+			assemblies = assemblies ?? new List<Assembly>();
+			foreach (var assembly in assemblyLocations)
+				assemblies.Add(Assembly.ReflectionOnlyLoadFrom(assembly));
+
+			return assemblies;
+		}
+
+		public IList<Assembly> AndroidAssemblies { get; private set; }
+
+		public IList<Assembly> AndroidXAssemblies { get; private set; }
+
+		public Dictionary<string, string> Namespaces { get; private set; }
+
+		public Dictionary<string, string> FullTypeNames { get; private set; }
+
+		public Dictionary<string, KeyValuePair<string, string>> Nugets { get; private set; }
+	}
+
+	public interface ITranslationResolver
+	{
+		IList<Assembly> AndroidAssemblies { get; }
+		IList<Assembly> AndroidXAssemblies { get; }
+
+		Dictionary<string, string> Namespaces { get; }
+		Dictionary<string, string> FullTypeNames { get; }
+
+		Dictionary<string, KeyValuePair<string, string>> Nugets { get; }
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Test/NameTests.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/NameTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	[TestClass]
+	public class NameTests : TestBase
+	{
+		[TestMethod]
+		public void when_defining_fully_qualified_fields_then_replace_namespace()
+		{
+			var solution = CreateSolution(@"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+				Android.Arch.Lifecycle.ViewModelProviders modelProvider;
+			}
+		}");
+
+			var methodFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("AndroidX.Lifecycle.ViewModelProviders"));
+			Assert.IsFalse(root.Contains("Android.Arch.Lifecycle.ViewModelProviders"));
+		}
+
+		[TestMethod]
+		public void when_defining_fully_qualified_properties_then_replace_namespace()
+		{
+			var file = @"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+				Android.Arch.Lifecycle.ViewModelProviders modelProvider { get; set; }
+			}
+		}";
+
+			var solution = CreateSolution(file);
+
+			var methodFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("AndroidX.Lifecycle.ViewModelProviders"));
+			Assert.IsFalse(root.Contains("Android.Arch.Lifecycle.ViewModelProviders"));
+		}
+
+		[TestMethod]
+		public void when_defining_fully_qualified_parameters_then_replace_namespace()
+		{
+			var solution = CreateSolution(@"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+				public void Method(Android.Arch.Lifecycle.ViewModelProviders modelProvider)
+				{
+				}
+			}
+		}");
+
+			var methodFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("public void Method(AndroidX.Lifecycle.ViewModelProviders modelProvider)"));
+			Assert.IsFalse(root.Contains("public void Method(Android.Arch.Lifecycle.ViewModelProviders modelProvider)"));
+		}
+
+		[TestMethod]
+		public void when_defining_fully_qualified_return_then_replace_namespace()
+		{
+			var solution = CreateSolution(@"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+				public Android.Arch.Lifecycle.ViewModelProviders Method()
+				{
+					return null;
+				}
+			}
+		}");
+
+			var methodFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("AndroidX.Lifecycle.ViewModelProviders"));
+			Assert.IsFalse(root.Contains("Android.Arch.Lifecycle.ViewModelProviders"));
+		}
+
+
+		[TestMethod]
+		public void when_defining_attribute_then_replace_attribute_name()
+		{
+			var solution = CreateSolution(@"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			[Android.Support.V17.Leanback.Widget.Visibility]
+			public class Class1 
+			{
+			}
+		}");
+
+			var methodFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("AndroidX.Leanback.Widget.Visibility"));
+			Assert.IsFalse(root.Contains("Android.Support.V17.Leanback.Widget.Visibility"));
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Test/NamespaceTests.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/NamespaceTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	[TestClass]
+	public class NamespaceTests : TestBase
+	{
+		[TestMethod]
+		public void when_defining_namespaces_then_replace_namespace()
+		{
+			var solution = CreateSolution(@"
+		using System;
+		using Android.Arch.Lifecycle;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+			}
+		}");
+
+			var methodFixer = new NamespaceRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("using AndroidX.Lifecycle;"));
+			Assert.IsFalse(root.Contains("using Android.Arch.Lifecycle;"));
+		}
+
+		[TestMethod]
+		public void when_defining_aliased_namespaces_then_replace_namespace()
+		{
+			var solution = CreateSolution(@"
+		using System;
+		using life = Android.Arch.Lifecycle;
+
+		namespace ClassLibrary1 
+		{
+			public class Class1 
+			{
+			}
+		}");
+
+			var methodFixer = new NamespaceRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains("using life = AndroidX.Lifecycle;"));
+			Assert.IsFalse(root.Contains("using life = Android.Arch.Lifecycle;"));
+		}
+
+		[TestMethod]
+		public void when_defining_aliased_namespaces_then_fully_qualify_if_needed()
+		{
+			var solution = CreateSolution(@"
+		using System;
+		using support = Android.Support;
+
+		namespace ClassLibrary1 
+		{
+			public class MainActivity : support.V7.App.AppCompatActivity 
+			{
+			}
+		}");
+
+			var methodFixer = new SemanticRewriter(resolver);
+			var typeFixer = new TypeRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+			solution = typeFixer.Visit(solution, GetFirstDocument(solution));
+
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains(": AndroidX.AppCompat.App.AppCompatActivity"));
+			Assert.IsFalse(root.Contains(": support.V7.App.AppCompatActivity"));
+		}
+
+		[TestMethod]
+		public void when_defining_types_then_dont_break_fully_qualified()
+		{
+			var solution = CreateSolution(@"
+		using System;
+
+		namespace ClassLibrary1 
+		{
+			public class MainActivity : Android.Support.V7.App.AppCompatActivity 
+			{
+			}
+		}");
+
+			var methodFixer = new SemanticRewriter(resolver);
+			solution = methodFixer.Visit(solution, GetFirstDocument(solution));
+			
+			var root = GetText(solution);
+
+			Assert.IsTrue(root.Contains(": Android.Support.V7.App.AppCompatActivity"));
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Test/ProjectTests.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/ProjectTests.cs
@@ -1,0 +1,571 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	[TestClass]
+	public class ProjectTests
+	{
+		[TestMethod]
+		public void when_nuget_version_is_not_inlined_replace_it()
+		{
+			var csproj = versionedCsProj;
+
+			var resolver = new TranslationResolver(new List<string>(), new List<string> { });
+			var projectFixer = new ProjectRewriter(resolver);
+
+			csproj = projectFixer.RewriteCSProj(csproj);
+
+			Assert.IsTrue(csproj.Contains(@"<PackageReference Include=""Xamarin.Google.Android.Material"">"));
+			Assert.IsFalse(csproj.Contains(@"<Version>28.0.0.1</Version>"));
+			Assert.IsTrue(csproj.Contains(@"<Version>1.0.0-preview01</Version>")); //replace version number
+			Assert.IsTrue(csproj.Contains(@"<Version>27.0.0.1</Version>")); //don't remove version for xamarin.essentials
+		}
+		
+
+		[TestMethod]
+		public void when_nuget_is_àppcompat_replace_with_androidx()
+		{
+			var csproj = sampleCsProj;
+
+			var resolver = new TranslationResolver(new List<string>(), new List<string> { });
+			var projectFixer = new ProjectRewriter(resolver);
+
+			csproj = projectFixer.RewriteCSProj(csproj);
+
+			Assert.IsTrue(csproj.Contains(@"<PackageReference Include=""Xamarin.AndroidX.Core"" Version=""1.0.1-preview01"" />"));
+		}
+
+
+		[TestMethod]
+		public void when_version_is_inline_replace_inline()
+		{
+			var csproj = sampleCsProj;
+
+			var resolver = new TranslationResolver(new List<string>(), new List<string> { });
+			var projectFixer = new ProjectRewriter(resolver);
+
+			csproj = projectFixer.RewriteCSProj(csproj);
+
+			Assert.IsTrue(csproj.Contains(@"<PackageReference Include=""Xamarin.AndroidX.Browser"" Version=""1.0.0-preview01"" />"));
+		}
+
+		[TestMethod]
+		public void in_poolmath_replace_androidx()
+		{
+			var csproj = poolMathCsproj;
+
+			var resolver = new TranslationResolver(new List<string>(), new List<string> { });
+			var projectFixer = new ProjectRewriter(resolver);
+
+			csproj = projectFixer.RewriteCSProj(csproj);
+
+			Assert.IsTrue(csproj.Contains(@"<PackageReference Include=""Xamarin.AndroidX.Core"">
+      <Version>1.0.1-preview01</Version>
+    </PackageReference>"));
+		}
+
+		[TestMethod]
+		public void when_nuget_is_support_replace_with_androidx()
+		{
+			var csproj = sampleCsProj;
+
+			var resolver = new TranslationResolver(new List<string>(), new List<string> { });
+			var projectFixer = new ProjectRewriter(resolver);
+				
+			csproj = projectFixer.RewriteCSProj(csproj);
+
+			Assert.IsTrue(csproj.Contains(@"<PackageReference Include=""Xamarin.Google.Android.Material"" Version=""1.0.0-preview01"" />"));
+		}
+
+		string sampleCsProj =
+			@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EA94CF80-A750-4881-9468-638D0472C6C9}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{84dd83c5-0fe3-4294-9419-09e7c8ba324f}</TemplateGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>App43</RootNamespace>
+    <AssemblyName>App43</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Xml"" />
+    <Reference Include=""System.Core"" />
+    <Reference Include=""Mono.Android"" />
+    <Reference Include=""System.Numerics"" />
+    <Reference Include=""System.Numerics.Vectors"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""MainActivity.cs"" />
+    <Compile Include=""Resources\Resource.designer.cs"" />
+    <Compile Include=""Properties\AssemblyInfo.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=""Resources\AboutResources.txt"" />
+    <None Include=""Properties\AndroidManifest.xml"" />
+    <None Include=""Assets\AboutAssets.txt"" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include=""Resources\layout\activity_main.axml"">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include=""Resources\layout\content_main.axml"">
+          <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include=""Resources\values\colors.xml"" />
+    <AndroidResource Include=""Resources\values\dimens.xml"" />
+    <AndroidResource Include=""Resources\values\ic_launcher_background.xml"" />
+    <AndroidResource Include=""Resources\values\strings.xml"" />
+    <AndroidResource Include=""Resources\values\styles.xml"" />
+    <AndroidResource Include=""Resources\menu\menu_main.xml"" />
+    <AndroidResource Include=""Resources\mipmap-anydpi-v26\ic_launcher.xml"" />
+    <AndroidResource Include=""Resources\mipmap-anydpi-v26\ic_launcher_round.xml"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher_round.png"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""Xamarin.Android.Support.Design"" Version=""28.0.0.1"" />
+    <PackageReference Include=""Xamarin.Android.Support.Core.Utils"" Version=""28.0.0.1"" />
+    <PackageReference Include=""Xamarin.Android.Support.CustomTabs"" Version=""28.0.0.1"" />
+    <PackageReference Include=""Xamarin.Essentials"" Version=""1.1.0"" />
+	<PackageReference Include=""Xamarin.Android.Support.Compat"" />
+  </ItemGroup>
+  <Import Project=""$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets"" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+    Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name=""BeforeBuild"">
+    </Target>
+    <Target Name=""AfterBuild"">
+    </Target>
+  -->
+</Project>";
+
+
+		string versionedCsProj =
+			@"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""4.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{EA94CF80-A750-4881-9468-638D0472C6C9}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TemplateGuid>{84dd83c5-0fe3-4294-9419-09e7c8ba324f}</TemplateGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>App43</RootNamespace>
+    <AssemblyName>App43</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>False</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugSymbols>True</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <Optimize>True</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Xml"" />
+    <Reference Include=""System.Core"" />
+    <Reference Include=""Mono.Android"" />
+    <Reference Include=""System.Numerics"" />
+    <Reference Include=""System.Numerics.Vectors"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""MainActivity.cs"" />
+    <Compile Include=""Resources\Resource.designer.cs"" />
+    <Compile Include=""Properties\AssemblyInfo.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=""Resources\AboutResources.txt"" />
+    <None Include=""Properties\AndroidManifest.xml"" />
+    <None Include=""Assets\AboutAssets.txt"" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include=""Resources\layout\activity_main.axml"">
+      <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include=""Resources\layout\content_main.axml"">
+          <SubType>Designer</SubType>
+    </AndroidResource>
+    <AndroidResource Include=""Resources\values\colors.xml"" />
+    <AndroidResource Include=""Resources\values\dimens.xml"" />
+    <AndroidResource Include=""Resources\values\ic_launcher_background.xml"" />
+    <AndroidResource Include=""Resources\values\strings.xml"" />
+    <AndroidResource Include=""Resources\values\styles.xml"" />
+    <AndroidResource Include=""Resources\menu\menu_main.xml"" />
+    <AndroidResource Include=""Resources\mipmap-anydpi-v26\ic_launcher.xml"" />
+    <AndroidResource Include=""Resources\mipmap-anydpi-v26\ic_launcher_round.xml"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-hdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-mdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xhdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxhdpi\ic_launcher_round.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher_foreground.png"" />
+    <AndroidResource Include=""Resources\mipmap-xxxhdpi\ic_launcher_round.png"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""Xamarin.Android.Support.Design"" >
+		<Version>28.0.0.1</Version>
+	</PackageReference>
+    <PackageReference Include=""Xamarin.Essentials"" Version=""1.1.0"" >
+		<Version>27.0.0.1</Version>
+	</PackageReference>
+  </ItemGroup>
+  <Import Project=""$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets"" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+    Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name=""BeforeBuild"">
+    </Target>
+    <Target Name=""AfterBuild"">
+    </Target>
+  -->
+</Project>";
+
+		string poolMathCsproj = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project DefaultTargets=""Build"" ToolsVersion=""4.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProjectGuid>{C62B0A31-9EF4-46F9-A4FA-2CCDA1937444}</ProjectGuid>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <RootNamespace>TroubleFreePool.Droid</RootNamespace>
+    <AssemblyName>com.troublefreepool.poolmath</AssemblyName>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <AndroidApplication>True</AndroidApplication>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
+    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
+    <AndroidSupportedAbis>arm64-v8a;armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
+    <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
+    <AndroidKeyStore>
+    </AndroidKeyStore>
+    <AndroidSigningKeyStore>..\Signing\poolmath.keystore</AndroidSigningKeyStore>
+    <AndroidSigningStorePass>poolmath</AndroidSigningStorePass>
+    <AndroidSigningKeyAlias>poolmath</AndroidSigningKeyAlias>
+    <AndroidSigningKeyPass>poolmath</AndroidSigningKeyPass>
+    <EnableProguard>true</EnableProguard>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidKeyStore>True</AndroidKeyStore>
+    <AndroidSigningKeyStore>..\Signing\poolmath.keystore</AndroidSigningKeyStore>
+    <AndroidSigningStorePass>poolmath</AndroidSigningStorePass>
+    <AndroidSigningKeyAlias>poolmath</AndroidSigningKeyAlias>
+    <AndroidSigningKeyPass>poolmath</AndroidSigningKeyPass>
+    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AotAssemblies>true</AotAssemblies>
+    <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <JavaOptions>-Xss4096k</JavaOptions>
+    <EnableLLVM>true</EnableLLVM>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'AppStore|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidManagedSymbols>true</AndroidManagedSymbols>
+    <AndroidKeyStore>True</AndroidKeyStore>
+    <AndroidSigningKeyStore>..\Signing\poolmath.keystore</AndroidSigningKeyStore>
+    <AndroidSigningStorePass>poolmath</AndroidSigningStorePass>
+    <AndroidSigningKeyAlias>poolmath</AndroidSigningKeyAlias>
+    <AndroidSigningKeyPass>poolmath</AndroidSigningKeyPass>
+    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a</AndroidSupportedAbis>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AotAssemblies>true</AotAssemblies>
+    <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
+    <JavaOptions>-Xss4096k</JavaOptions>
+    <EnableLLVM>true</EnableLLVM>
+    <DefineConstants>APPSTORE;</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="" $(SolutionDir) == '' "">
+    <SolutionDir>$(MSBuildThisFileDirectory)..\</SolutionDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AndroidSdkBuildToolsVersion>26.0.2</AndroidSdkBuildToolsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Xml"" />
+    <Reference Include=""System.Core"" />
+    <Reference Include=""Mono.Android"" />
+    <Reference Include=""System.Net.Http"" />
+    <Reference Include=""Mono.Android.Export"" />
+    <Reference Include=""System.IO.Compression"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include=""Effects\RoundTheCornersEffectAndroid.cs"" />
+    <Compile Include=""MainActivity.cs"" />
+    <Compile Include=""Renderers\BindablePickerRendererDroid.cs"" />
+    <Compile Include=""Renderers\DatePickerRenderer.cs"" />
+    <Compile Include=""Renderers\HumbleEntryRendererAndroid.cs"" />
+    <Compile Include=""Resources\Resource.designer.cs"" />
+    <Compile Include=""Properties\AssemblyInfo.cs"" />
+    <Compile Include=""MainApplication.cs"" />
+    <Compile Include=""Renderers\MenuViewCellRenderer.cs"" />
+    <Compile Include=""Renderers\SelectAllEntryRenderer.cs"" />
+    <Compile Include=""Renderers\ChemicalOverviewRenderer.cs"" />
+    <Compile Include=""Services\AccentColorService.cs"" />
+    <Compile Include=""Services\SubscriptionService.cs"" />
+    <Compile Include=""SplashActivity.cs"" />
+    <Compile Include=""Renderers\CardContentViewRendererDroid.cs"" />
+    <Compile Include=""Renderers\SelectAllExtendedEntryRenderer.cs"" />
+    <Compile Include=""AuthProvider\FacebookAuthProvider.cs"" />
+    <Compile Include=""AuthProvider\GoogleAuthProvider.cs"" />
+    <Compile Include=""Renderers\NavigationViewRenderer.cs"" />
+    <Compile Include=""Services\ExportFileService.cs"" />
+    <Compile Include=""Services\HudService.cs"" />
+    <Compile Include=""Renderers\ChemicalOutlineFrameRenderer.cs"" />
+  </ItemGroup>
+  <ItemGroup>
+    <GoogleServicesJson Include=""google-services.json"" />
+    <None Include=""Resources\AboutResources.txt"" />
+    <None Include=""Properties\AndroidManifest.xml"" />
+    <None Include=""Assets\AboutAssets.txt"" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include=""Resources\drawable\loginbg.png"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProguardConfiguration Include=""proguard\proguard.cfg"" />
+    <ProguardConfiguration Include=""proguard\proguard-gps.txt"" />
+    <ProguardConfiguration Include=""proguard.txt"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""AndHUD"">
+      <Version>1.4.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Annotations"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v7.CardView"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Core.Utils"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Core.UI"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Compat"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Design"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.Fragment"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v7.AppCompat"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v7.MediaRouter"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v7.RecyclerView"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v7.Palette"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Android.Support.v4"">
+      <Version>28.0.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.GooglePlayServices.Auth"">
+      <Version>60.1142.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Newtonsoft.Json"">
+      <Version>12.0.1</Version>
+    </PackageReference>
+    <PackageReference Include=""Microsoft.AppCenter"">
+      <Version>1.14.0</Version>
+    </PackageReference>
+    <PackageReference Include=""Microsoft.AppCenter.Analytics"">
+      <Version>1.14.0</Version>
+    </PackageReference>
+    <PackageReference Include=""Microsoft.AppCenter.Crashes"">
+      <Version>1.14.0</Version>
+    </PackageReference>
+    <PackageReference Include=""Microsoft.AppCenter.Distribute"">
+      <Version>1.14.0</Version>
+    </PackageReference>
+    <PackageReference Include=""Microsoft.AppCenter.Push"">
+      <Version>1.14.0</Version>
+    </PackageReference>
+    <PackageReference Include=""MonkeyCache"">
+      <Version>1.2.0-beta</Version>
+    </PackageReference>
+    <PackageReference Include=""MonkeyCache.FileStore"">
+      <Version>1.2.0-beta</Version>
+    </PackageReference>
+    <PackageReference Include=""NETStandard.Library"">
+      <Version>2.0.3</Version>
+    </PackageReference>
+    <PackageReference Include=""Plugin.InAppBilling"">
+      <Version>2.1.0.187-beta</Version>
+    </PackageReference>
+    <PackageReference Include=""Plugin.Permissions"">
+      <Version>3.0.0.12</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Build.Download"">
+      <Version>0.4.12-preview3</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Facebook.Android"">
+      <Version>4.38.0</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Forms"">
+      <Version>3.6.0.344457</Version>
+    </PackageReference>
+    <PackageReference Include=""Humanizer.Core"">
+      <Version>2.5.16</Version>
+    </PackageReference>
+    <PackageReference Include=""Xamarin.Essentials"">
+      <Version>1.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\PoolMath.Core\PoolMath.Core.csproj"">
+      <Project>{E0A1FD19-6E12-449D-8C07-5A00EB73C465}</Project>
+      <Name>PoolMath.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include=""..\PoolMathApp.Share\PoolMathApp.Share.csproj"">
+      <Project>{C6C52109-A9B0-4027-A9A3-F1D2A3314F0E}</Project>
+      <Name>PoolMathApp.Share</Name>
+    </ProjectReference>
+    <ProjectReference Include=""..\AmazonIap\AmazonIap.csproj"">
+      <Project>{B986F10C-01CB-4F0A-881D-29C06A91DF89}</Project>
+      <Name>AmazonIap</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project=""$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets"" />
+</Project>
+";
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Test/Properties/AssemblyInfo.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Test")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("2e87329e-6b9a-4f80-9d80-a3147b15bba9")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/VisualStudio.AndroidX.Migration/Test/ResolverTests.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/ResolverTests.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	[TestClass]
+	public class ResolverTests
+	{
+		[TestMethod]
+		public void when_translation_resolver_doesnt_have_assemblies_it_still_initializes()
+		{
+			var resolver = new TranslationResolver(null, null);
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/Test/Test.csproj
+++ b/source/VisualStudio.AndroidX.Migration/Test/Test.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>VisualStudio.AndroidX.Migration</RootNamespace>
+    <AssemblyName>VisualStudio.AndroidX.Migration.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NamespaceTests.cs" />
+    <Compile Include="NameTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResolverTests.cs" />
+    <Compile Include="TestBase.cs" />
+    <Compile Include="ProjectTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter">
+      <Version>1.3.2</Version>
+    </PackageReference>
+    <PackageReference Include="MSTest.TestFramework">
+      <Version>1.3.2</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Assemblies\AndroidX\Xamarin.AndroidX.AppCompat.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assemblies\AndroidX\Xamarin.AndroidX.Leanback.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assemblies\AndroidX\Xamarin.AndroidX.Lifecycle.Common.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assemblies\Android\Xamarin.Android.Arch.Lifecycle.Common.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assemblies\Android\Xamarin.Android.Support.v17.Leanback.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assemblies\Android\Xamarin.Android.Support.v7.AppCompat.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj">
+      <Project>{297b120f-de08-4460-bce6-5b2a74535c2d}</Project>
+      <Name>Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/source/VisualStudio.AndroidX.Migration/Test/TestBase.cs
+++ b/source/VisualStudio.AndroidX.Migration/Test/TestBase.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace VisualStudio.AndroidX.Migration
+{
+	public class TestBase
+	{
+		internal static ITranslationResolver resolver;
+
+		static TestBase()
+		{
+			var assembliesDirectory = Path.Combine(Path.GetDirectoryName(typeof(NameTests).Assembly.Location), "Assemblies\\Android");
+
+			resolver = new TranslationResolver(Directory.GetFiles(assembliesDirectory), new List<string> { });
+		}
+
+
+		public static Solution CreateSolution(string file)
+		{
+			var workspace = new AdhocWorkspace();
+			var project = workspace.AddProject("MethodTest", "C#");
+			foreach (var assembly in resolver.AndroidAssemblies)
+				project = project.AddMetadataReference(MetadataReference.CreateFromFile(assembly.Location));
+			var document = project.AddDocument("Class1.cs", file);
+			return document.Project.Solution;
+		}
+
+		internal static string GetText(Solution solution)
+		{
+			return solution.Projects.First().Documents.First().GetSyntaxRootAsync().Result.ToFullString();
+		}
+
+		internal static Document GetFirstDocument(Solution solution)
+		{
+			return solution.Projects.First().Documents.First();
+		}
+	}
+}

--- a/source/VisualStudio.AndroidX.Migration/VisualStudio.AndroidX.Migration.sln
+++ b/source/VisualStudio.AndroidX.Migration/VisualStudio.AndroidX.Migration.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.443
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", "{297B120F-DE08-4460-BCE6-5B2A74535C2D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console", "Console\Console.csproj", "{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2E87329E-6B9A-4F80-9D80-A3147B15BBA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{297B120F-DE08-4460-BCE6-5B2A74535C2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{297B120F-DE08-4460-BCE6-5B2A74535C2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{297B120F-DE08-4460-BCE6-5B2A74535C2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{297B120F-DE08-4460-BCE6-5B2A74535C2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29E0E329-B35E-4A6C-B24D-E4700C6BA58F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {77E00823-76E8-4B60-ABF0-181ABA21AE6C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This is just the Roslyn part. It will generate a nuget on build (on a different commit) and that will be used from VS and VSMac to integrate the migration with the IDEs. The test require a few AndroidX dlls not included in the commit (because I'm not commiting binaries). They can be manually downloaded if needed, added as a nuget or used from a parent compilation.