### PR TITLE
Support versions of XA without linksrc directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,4 @@ lint/tmp/
 # lint/reports/
 /Cecilfier/samples/Xamarin.AndroidX.Cecilfier.App/.vscode/launch.json
 /Cecilfier/samples/Xamarin.AndroidX.Cecilfier.App/.vscode/tasks.json
+Resource.designer.cs

--- a/source/Xamarin.AndroidX.Migration/BuildTasks/Xamarin.AndroidX.Migration.targets
+++ b/source/Xamarin.AndroidX.Migration/BuildTasks/Xamarin.AndroidX.Migration.targets
@@ -150,8 +150,38 @@
     <Target Name="_AndroidXCecilfyShrinkFindFiles"
             Condition="'$(_AndroidXShouldRunMigration)' == 'true' and '$(AndroidLinkMode)' != 'none'">
         <ItemGroup>
-            <_AndroidXFileToCecilfy Include="@(ResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')"
-                                    Condition="'%(ResolvedUserAssemblies.AndroidXSkipAndroidXMigration)' != 'true'" />
+            <_AndroidXResolvedUserAssemblies Condition="'%(ResolvedUserAssemblies.AndroidXSkipAndroidXMigration)' != 'true'"
+                                         Include="@(ResolvedUserAssemblies)" />
+            <_AndroidXFileToCecilfy Condition="'$(MonoAndroidLinkerInputDir)' != ''"
+                                    Include="@(_AndroidXResolvedUserAssemblies->'$(MonoAndroidLinkerInputDir)%(Filename)%(Extension)')" />
+        </ItemGroup>
+    </Target>
+
+    <!-- In Xamarin.Android 10.1, linksrc does not exist -->
+    <Target Name="_AndroidXCecilfyShrinkCopyFiles"
+            Condition="'$(_AndroidXShouldRunMigration)' == 'true' and '$(AndroidLinkMode)' != 'none' and '$(MonoAndroidLinkerInputDir)' == ''"
+            Inputs="@(ResolvedAssemblies)"
+            Outputs="@(ResolvedAssemblies->'$(IntermediateOutputPath)androidx\cecil\%(Filename)%(Extension)')">
+        <ItemGroup>
+            <_AndroidXResolvedPdbs Include="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename).pdb')" />
+            <_AndroidXResolvedMdbs Include="@(ResolvedAssemblies->'%(RootDir)%(Directory)%(Filename)%(Extension).mdb')" />
+            <_AndroidXResolvedSymbols Condition="Exists(%(Identity))" Include="@(_AndroidXResolvedPdbs);@(_AndroidXResolvedMdbs)" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(ResolvedAssemblies)"
+            DestinationFiles="@(ResolvedAssemblies->'$(IntermediateOutputPath)androidx\cecil\%(Filename)%(Extension)')"
+        />
+        <Copy
+            SourceFiles="@(_AndroidXResolvedSymbols)"
+            DestinationFiles="@(_AndroidXResolvedSymbols->'$(IntermediateOutputPath)androidx\cecil\%(Filename)%(Extension)')"
+        />
+        <ItemGroup>
+            <_AndroidXFileToCecilfy Include="@(_AndroidXResolvedUserAssemblies->'$(IntermediateOutputPath)androidx\cecil\%(Filename)%(Extension)')" />
+            <!--Fix up our existing item groups-->
+            <ResolvedAssemblies Remove="@(_AndroidXResolvedUserAssemblies)" />
+            <ResolvedAssemblies Include="@(_AndroidXFileToCecilfy)" />
+            <ResolvedUserAssemblies Remove="@(_AndroidXResolvedUserAssemblies)" />
+            <ResolvedUserAssemblies Include="@(_AndroidXFileToCecilfy)" />
         </ItemGroup>
     </Target>
 
@@ -174,7 +204,7 @@
     </Target>
 
     <Target Name="_AndroidXCecilfy"
-            DependsOnTargets="_AndroidXCecilfyShrinkFindFiles;_AndroidXCecilfyNoShrinkFindFiles"
+            DependsOnTargets="_AndroidXCecilfyShrinkFindFiles;_AndroidXCecilfyShrinkCopyFiles;_AndroidXCecilfyNoShrinkFindFiles"
             Inputs="@(_AndroidXFileToCecilfy);$(_AndroidStampDirectory)_CopyIntermediateAssemblies.stamp"
             Outputs="$(_AndroidStampDirectory)_AndroidXCecilfy.stamp"
             Condition="'$(_AndroidXShouldRunMigration)' == 'true'">


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/commit/2ea31e6f02c11d4da1a752e74552d86df416d1ea
Context: https://github.com/xamarin/xamarin-android/compare/master...jonathanpeppers:androidx-migration-test

To improve build performance we have dropped the `linksrc` directory
from Xamarin.Android. This dramatically improved the overall file size
of the `obj` directory and helped with PCs running Windows Defender.

This unfortunately broke the AndroidX.Migration for `Release` builds,
but we can fix it:

* If `$(MonoAndroidLinkerInputDir)` is non-empty we can use the
  existing behavior, otherwise...
* We can do a `<Copy/>` of the assemblies to
  `obj\Release\androidx\cecil`.
  * pdb/mdb files, too!
* `<CecilfyFiles/>` can then use the files in `androidx\cecil`
  directory.
* Lastly, we will have to patch up `@(ResolvedAssemblies)` and
  `@(ResolvedUserAssemblies)` to use the new files.

Other changes:

* Updated `.gitignore` for `Resource.designer.cs`